### PR TITLE
Add pricing section with purple theme colors

### DIFF
--- a/lumora-client/src/app/globals.css
+++ b/lumora-client/src/app/globals.css
@@ -1,5 +1,51 @@
 @import "../../node_modules/tailwindcss";
 
+/* Add this to your globals.css file */
+
+@import "tailwindcss/theme";
+@import "tailwindcss/utilities";
+
+@theme {
+  /* Primary Purple Palette */
+  --color-primary-50: #faf5ff;
+  --color-primary-100: #f3e8ff;
+  --color-primary-200: #e9d5ff;
+  --color-primary-300: #d8b4fe;
+  --color-primary-400: #c084fc;
+  --color-primary-500: #a855f7;
+  --color-primary-600: #9333ea;
+  --color-primary-700: #7c3aed;
+  --color-primary-800: #6b21a8;
+  --color-primary-900: #581c87;
+  --color-primary-950: #3b0764;
+
+  /* Secondary Purple Palette (darker variant) */
+  --color-secondary-50: #f8f4ff;
+  --color-secondary-100: #ede4ff;
+  --color-secondary-200: #ddd0ff;
+  --color-secondary-300: #c2a8ff;
+  --color-secondary-400: #a374ff;
+  --color-secondary-500: #8b46ff;
+  --color-secondary-600: #7c3aed;
+  --color-secondary-700: #6d28d9;
+  --color-secondary-800: #5b21b6;
+  --color-secondary-900: #4c1d95;
+  --color-secondary-950: #2e1065;
+
+  /* Accent Purple Palette (lighter variant) */
+  --color-accent-50: #fdf4ff;
+  --color-accent-100: #fae8ff;
+  --color-accent-200: #f5d0fe;
+  --color-accent-300: #f0abfc;
+  --color-accent-400: #e879f9;
+  --color-accent-500: #d946ef;
+  --color-accent-600: #c026d3;
+  --color-accent-700: #a21caf;
+  --color-accent-800: #86198f;
+  --color-accent-900: #701a75;
+  --color-accent-950: #4a044e;
+}
+
 :root {
   /*====== GENERAL ======*/
   /* colors */

--- a/lumora-client/src/app/globals.css
+++ b/lumora-client/src/app/globals.css
@@ -76,12 +76,6 @@
   }
 }
 
-*{
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
 body {
   background: var(--background);
   color: var(--foreground);

--- a/lumora-client/src/components/Pricing/Pricing.tsx
+++ b/lumora-client/src/components/Pricing/Pricing.tsx
@@ -2,6 +2,11 @@
 
 import Button from "../Button/Button";
 
+interface PricingGroup {
+  title: string;
+  features: Array<{ label: string }>;
+}
+
 const PricingCard = ({ title, features }: PricingGroup) => {
   return (
     <div className="border rounded-3xl border-primary-500 shadow-md max-w-lg p-10 w-sm">
@@ -20,11 +25,6 @@ const PricingCard = ({ title, features }: PricingGroup) => {
     </div>
   );
 };
-
-interface PricingGroup {
-  title: string;
-  features: Array<{ label: string }>;
-}
 
 const Pricing = () => {
   const pricingGroups: PricingGroup[] = [

--- a/lumora-client/src/components/Pricing/Pricing.tsx
+++ b/lumora-client/src/components/Pricing/Pricing.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode } from "react";
+import Button from "../Button/Button";
 
 interface PricingGroup {
   title: string;
@@ -41,21 +41,29 @@ const Pricing = () => {
 
   return (
     <section className="bg-gray-800 text-white py-10 px-25">
-      <h2 className="text-center text-5xl mb-10">Choose Your Plan</h2>
-      <div className="grid grid-cols-1 md:grid-cols-3 justify-items-center">
+      <h2 className="text-center text-5xl font-extrabold tracking-tighter mb-10">
+        Choose Your Plan
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 justify-items-center max-w-10xl">
         {pricingGroups.map((group) => (
           <div
             key={group.title}
-            className="border rounded-lg shadow-md max-w-lg p-6 w-sm"
+            className="border rounded-3xl border-primary-500 shadow-md max-w-lg p-10 w-sm"
           >
-            <h4 className="text-4xl text-center my-4">{group.title}</h4>
-            <ul className="mt-4">
+            <h4 className="text-4xl text-center mt-4 font-extrabold">
+              {group.title}
+            </h4>
+            <ul className="my-10">
               {group.features.map((feature) => (
-                <li className="text-center text-lg mb-3" key={feature.label}>
+                <li
+                  className="text-center text-lg mb-3 pb-3 border-b border-gray-700"
+                  key={feature.label}
+                >
                   {feature.label}
                 </li>
               ))}
             </ul>
+            <Button />
           </div>
         ))}
       </div>

--- a/lumora-client/src/components/Pricing/Pricing.tsx
+++ b/lumora-client/src/components/Pricing/Pricing.tsx
@@ -40,15 +40,20 @@ const Pricing = () => {
   ];
 
   return (
-    <section className="bg-gray-800 text-white">
-      <h2 className="text-center text-3xl">Choose Your Plan</h2>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+    <section className="bg-gray-800 text-white py-10 px-25">
+      <h2 className="text-center text-5xl mb-10">Choose Your Plan</h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 justify-items-center">
         {pricingGroups.map((group) => (
-          <div key={group.title} className="border rounded-lg p-6 shadow-md">
-            <h4>{group.title}</h4>
-            <ul>
+          <div
+            key={group.title}
+            className="border rounded-lg shadow-md max-w-lg p-6 w-sm"
+          >
+            <h4 className="text-4xl text-center my-4">{group.title}</h4>
+            <ul className="mt-4">
               {group.features.map((feature) => (
-                <p key={feature.label}>{feature.label}</p>
+                <li className="text-center text-lg mb-3" key={feature.label}>
+                  {feature.label}
+                </li>
               ))}
             </ul>
           </div>

--- a/lumora-client/src/components/Pricing/Pricing.tsx
+++ b/lumora-client/src/components/Pricing/Pricing.tsx
@@ -2,6 +2,25 @@
 
 import Button from "../Button/Button";
 
+const PricingCard = ({ title, features }: PricingGroup) => {
+  return (
+    <div className="border rounded-3xl border-primary-500 shadow-md max-w-lg p-10 w-sm">
+      <h4 className="text-4xl text-center mt-4 font-extrabold">{title}</h4>
+      <ul className="my-10">
+        {features.map((feature) => (
+          <li
+            className="text-center text-lg mb-3 pb-3 border-b border-gray-700"
+            key={feature.label}
+          >
+            {feature.label}
+          </li>
+        ))}
+      </ul>
+      <Button />
+    </div>
+  );
+};
+
 interface PricingGroup {
   title: string;
   features: Array<{ label: string }>;
@@ -46,25 +65,11 @@ const Pricing = () => {
       </h2>
       <div className="grid grid-cols-1 md:grid-cols-3 justify-items-center max-w-10xl">
         {pricingGroups.map((group) => (
-          <div
+          <PricingCard
             key={group.title}
-            className="border rounded-3xl border-primary-500 shadow-md max-w-lg p-10 w-sm"
-          >
-            <h4 className="text-4xl text-center mt-4 font-extrabold">
-              {group.title}
-            </h4>
-            <ul className="my-10">
-              {group.features.map((feature) => (
-                <li
-                  className="text-center text-lg mb-3 pb-3 border-b border-gray-700"
-                  key={feature.label}
-                >
-                  {feature.label}
-                </li>
-              ))}
-            </ul>
-            <Button />
-          </div>
+            title={group.title}
+            features={group.features}
+          />
         ))}
       </div>
     </section>

--- a/lumora-client/src/components/Pricing/Pricing.tsx
+++ b/lumora-client/src/components/Pricing/Pricing.tsx
@@ -1,13 +1,58 @@
-"use client"
+"use client";
 
-import styles from './Pricing.module.css'
+import { ReactNode } from "react";
 
-const Pricing = () => {
-    return(
-        <section className={styles.pricing}>
-            <p>Pricing Section</p>
-        </section>
-    )
+interface PricingGroup {
+  title: string;
+  features: Array<{ label: string }>;
 }
 
-export default Pricing
+const Pricing = () => {
+  const pricingGroups: PricingGroup[] = [
+    {
+      title: "Free",
+      features: [
+        { label: "5 watchlist stocks" },
+        { label: "Basic analytics" },
+        { label: "Email alerts" },
+        { label: "Daily news digest" },
+      ],
+    },
+    {
+      title: "Premium",
+      features: [
+        { label: "Unlimited watchlists" },
+        { label: "Fundamental analysis" },
+        { label: "Technical analysis" },
+        { label: "Retail & Suit Sentiment" },
+      ],
+    },
+    {
+      title: "Gold",
+      features: [
+        { label: "Unlimited watchlists" },
+        { label: "Fundamental analysis" },
+        { label: "Technical analysis" },
+        { label: "Retail & Suit Sentiment" },
+        { label: "Short interest" },
+      ],
+    },
+  ];
+
+  return (
+    <section className="bg-gray-800 text-white grid grid-cols-1 md:grid-cols-3 gap-8">
+      {pricingGroups.map((group) => (
+        <div key={group.title} className="border rounded-lg p-6 shadow-md">
+          <h4>{group.title}</h4>
+          <ul>
+            {group.features.map((feature) => (
+              <p key={feature.label}>{feature.label}</p>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </section>
+  );
+};
+
+export default Pricing;

--- a/lumora-client/src/components/Pricing/Pricing.tsx
+++ b/lumora-client/src/components/Pricing/Pricing.tsx
@@ -40,17 +40,20 @@ const Pricing = () => {
   ];
 
   return (
-    <section className="bg-gray-800 text-white grid grid-cols-1 md:grid-cols-3 gap-8">
-      {pricingGroups.map((group) => (
-        <div key={group.title} className="border rounded-lg p-6 shadow-md">
-          <h4>{group.title}</h4>
-          <ul>
-            {group.features.map((feature) => (
-              <p key={feature.label}>{feature.label}</p>
-            ))}
-          </ul>
-        </div>
-      ))}
+    <section className="bg-gray-800 text-white">
+      <h2 className="text-center text-3xl">Choose Your Plan</h2>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        {pricingGroups.map((group) => (
+          <div key={group.title} className="border rounded-lg p-6 shadow-md">
+            <h4>{group.title}</h4>
+            <ul>
+              {group.features.map((feature) => (
+                <p key={feature.label}>{feature.label}</p>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
     </section>
   );
 };


### PR DESCRIPTION
Built out the pricing component with three subscription tiers (Free, Premium, Gold) and added a comprehensive purple color palette to match the app's design system. I added excessive amount of colors for now so that we can have options and means to experiment, we can remove unused ones later.

Additionally I had to remove the global margin and padding reset that you added because it was breaking my Footer and was making it impossible to apply any padding and margin with thailwind, because the rule was overwriting everything. Removing of the reset didn't seem to break any of your work so please check on your side! @Itserge1 

<img width="1571" height="687" alt="Screenshot 2025-09-25 at 12 27 13 PM" src="https://github.com/user-attachments/assets/4c60da06-24a0-4c30-bdfe-9b09f44f0345" />
