### PR TITLE
Refactor Button component for better flexibility

### DIFF
--- a/lumora-client/package-lock.json
+++ b/lumora-client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "lumora-client",
       "version": "0.1.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "clsx": "^2.1.1",
         "next": "15.5.0",
         "react": "19.1.0",
@@ -213,6 +214,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/lumora-client/package.json
+++ b/lumora-client/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint --max-warnings=0"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "clsx": "^2.1.1",
     "next": "15.5.0",
     "react": "19.1.0",

--- a/lumora-client/src/components/Button/ActionButton.tsx
+++ b/lumora-client/src/components/Button/ActionButton.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+
+interface ButtonProps {
+  children: ReactNode;
+  variant?: "primary" | "secondary";
+  size?: "sm" | "md" | "lg";
+  className?: string;
+  href?: string;
+  disabled?: boolean;
+  loading?: boolean;
+  fullWidth?: boolean;
+  onClick?: () => void;
+}
+
+export function ActionButton({
+  children,
+  variant = "primary",
+  size = "md",
+  className = "",
+  href = "",
+  disabled = false,
+  loading = false,
+  fullWidth = false,
+  onClick,
+}: ButtonProps) {
+  const baseClasses =
+    "inline-flex items-center justify-center font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors";
+
+  const variantClasses = {
+    primary:
+      loading || disabled
+        ? "bg-primary-300 cursor-not-allowed text-white"
+        : "bg-primary-500 hover:bg-primary-600 text-white focus:ring-primary-500",
+    secondary:
+      "bg-white text-primary-500 border border-primary-500 hover:bg-gray-50 focus:ring-primary-500",
+  };
+
+  const sizeClasses = {
+    sm: "px-3 py-1.5 text-sm",
+    md: "px-4 py-2 text-sm",
+    lg: "px-6 py-3 text-base",
+  };
+
+  const widthClasses = fullWidth ? "w-full" : "";
+
+  const commonClasses = `${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${widthClasses} ${className}`;
+
+  if (href) {
+    return (
+      <a href={href} className={commonClasses}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <button onClick={onClick} className={commonClasses}>
+      {children}
+    </button>
+  );
+}

--- a/lumora-client/src/components/Pricing/Pricing.tsx
+++ b/lumora-client/src/components/Pricing/Pricing.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import Button from "../Button/Button";
+import { ArrowRightIcon } from "@heroicons/react/16/solid";
+import { ActionButton } from "../Button/ActionButton";
 
 interface PricingGroup {
   title: string;
@@ -21,7 +22,10 @@ const PricingCard = ({ title, features }: PricingGroup) => {
           </li>
         ))}
       </ul>
-      <Button />
+      <ActionButton size="lg" variant="primary" fullWidth>
+        <span className="font-bold">Sign Up</span>
+        <ArrowRightIcon className="size-5 ml-2" />
+      </ActionButton>
     </div>
   );
 };


### PR DESCRIPTION
Cleaned up the Button component by removing unnecessary wrapper elements, making it render as either <a> or <button> based on props, and simplified the API to accept any content as children instead of hard-coded text and icons.

Added the [heroicons](https://heroicons.com/) library.