### PR TITLE
Styling improvements for Pricing and Footer components

### DIFF
--- a/lumora-client/src/components/Button/ActionButton.tsx
+++ b/lumora-client/src/components/Button/ActionButton.tsx
@@ -31,7 +31,7 @@ export function ActionButton({
         ? "bg-primary-300 cursor-not-allowed text-white"
         : "bg-primary-500 hover:bg-primary-600 text-white focus:ring-primary-500",
     secondary:
-      "bg-white text-primary-500 border border-primary-500 hover:bg-gray-50 focus:ring-primary-500",
+      "bg-transparent text-primary-500 border border-primary-500 hover:border-primary-600 hover:text-primary-600  hover:shadow-sm hover:shadow-primary-600 focus:ring-primary-500",
   };
 
   const sizeClasses = {

--- a/lumora-client/src/components/Footer/Footer.tsx
+++ b/lumora-client/src/components/Footer/Footer.tsx
@@ -53,17 +53,17 @@ function Footer() {
   ];
 
   return (
-    <footer className="bg-gray-800 text-white py-12">
+    <footer className="py-12 px-6">
       <div className="container mx-auto px-4 grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-8">
-        <div className="col-span-1 lg:col-span-2 items-center text-center md:text-left">
+        <div className="col-span-1 lg:col-span-2 text-left">
           <h3 className="text-xl font-bold mb-4">Lumora</h3>
           <p className="text-gray-300">
             Intelligent stock news and insights for modern investors.
           </p>
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-3 col-span-1 md:col-span-2 gap-8">
+        <div className="grid grid-cols-2 md:grid-cols-3 col-span-1 md:col-span-2 gap-6 lg:gap-8">
           {linkGroups.map((group) => (
-            <div key={group.title} className="text-center md:text-left">
+            <div key={group.title} className="text-left">
               <h4 className="font-semibold mb-4">{group.title}</h4>
               <ul className="space-y-2">
                 {group.links.map((link) => (

--- a/lumora-client/src/components/Pricing/Pricing.tsx
+++ b/lumora-client/src/components/Pricing/Pricing.tsx
@@ -10,8 +10,8 @@ interface PricingGroup {
 
 const PricingCard = ({ title, features }: PricingGroup) => {
   return (
-    <div className="border rounded-3xl border-primary-500 shadow-md max-w-lg p-10 w-sm flex flex-col">
-      <h4 className="text-4xl text-center mt-4 font-extrabold">{title}</h4>
+    <div className="border rounded-3xl border-primary-500 shadow-md mb-6 sm:mb-8 md:mb-10 lg:mb-10 p-10 md:p-15 lg:p-10 w-full flex flex-col max-w-lg">
+      <h4 className="text-4xl text-center font-extrabold">{title}</h4>
       <ul className="my-10">
         {features.map((feature) => (
           <li
@@ -63,11 +63,11 @@ const Pricing = () => {
   ];
 
   return (
-    <section className="bg-gray-800 text-white py-10 px-25">
+    <section className="py-10 px-2 lg:px-10 xl:px-25 mx-6 sm:mx-10 md:mx-0">
       <h2 className="text-center text-5xl font-extrabold tracking-tighter mb-10">
         Choose Your Plan
       </h2>
-      <div className="grid grid-cols-1 md:grid-cols-3 justify-items-center max-w-10xl">
+      <div className="grid grid-cols-1 lg:grid-cols-3 justify-items-center max-w-10xl lg:gap-5 xl:gap-10">
         {pricingGroups.map((group) => (
           <PricingCard
             key={group.title}

--- a/lumora-client/src/components/Pricing/Pricing.tsx
+++ b/lumora-client/src/components/Pricing/Pricing.tsx
@@ -6,9 +6,10 @@ import { ActionButton } from "../Button/ActionButton";
 interface PricingGroup {
   title: string;
   features: Array<{ label: string }>;
+  button: string;
 }
 
-const PricingCard = ({ title, features }: PricingGroup) => {
+const PricingCard = ({ title, features, button }: PricingGroup) => {
   return (
     <div className="border rounded-3xl border-primary-500 shadow-md mb-6 sm:mb-8 md:mb-10 lg:mb-10 p-10 md:p-15 lg:p-10 w-full flex flex-col max-w-lg">
       <h4 className="text-4xl text-center font-extrabold">{title}</h4>
@@ -23,7 +24,7 @@ const PricingCard = ({ title, features }: PricingGroup) => {
         ))}
       </ul>
       <ActionButton size="lg" variant="primary" className="mt-auto" fullWidth>
-        <span className="font-bold">Sign Up</span>
+        <span className="font-bold">{button}</span>
         <ArrowRightIcon className="size-5 ml-2" />
       </ActionButton>
     </div>
@@ -40,6 +41,7 @@ const Pricing = () => {
         { label: "Email alerts" },
         { label: "Daily news digest" },
       ],
+      button: "Get Started",
     },
     {
       title: "Premium",
@@ -49,6 +51,7 @@ const Pricing = () => {
         { label: "Technical analysis" },
         { label: "Retail & Suit Sentiment" },
       ],
+      button: "Start Free Trial",
     },
     {
       title: "Gold",
@@ -59,6 +62,7 @@ const Pricing = () => {
         { label: "Retail & Suit Sentiment" },
         { label: "Short interest" },
       ],
+      button: "Start Free Trial",
     },
   ];
 
@@ -73,6 +77,7 @@ const Pricing = () => {
             key={group.title}
             title={group.title}
             features={group.features}
+            button={group.button}
           />
         ))}
       </div>

--- a/lumora-client/src/components/Pricing/Pricing.tsx
+++ b/lumora-client/src/components/Pricing/Pricing.tsx
@@ -23,7 +23,12 @@ const PricingCard = ({ title, features, button }: PricingGroup) => {
           </li>
         ))}
       </ul>
-      <ActionButton size="lg" variant="primary" className="mt-auto" fullWidth>
+      <ActionButton
+        size="lg"
+        variant={title === "Free" ? "secondary" : "primary"}
+        className="mt-auto"
+        fullWidth
+      >
         <span className="font-bold">{button}</span>
         <ArrowRightIcon className="size-5 ml-2" />
       </ActionButton>


### PR DESCRIPTION
Improved spacing and responsiveness for mobile devices (phones and tablets).

Also, what do you think about differenciating buttons depending if its a free tier (deemphasized) or starting a trial for premium?
<img width="597" height="732" alt="Screenshot 2025-09-29 at 8 56 12 PM" src="https://github.com/user-attachments/assets/ab65e1e6-90f8-44e2-8463-324ff63b11c2" />
<img width="530" height="672" alt="Screenshot 2025-09-29 at 7 46 32 PM" src="https://github.com/user-attachments/assets/0a03c15e-d4c8-4891-800b-067f808003de" />
<img width="497" height="672" alt="Screenshot 2025-09-29 at 7 46 19 PM" src="https://github.com/user-attachments/assets/38a80cb7-d3aa-4bb0-ba89-08231fd5fdd2" />
<img width="497" height="672" alt="Screenshot 2025-09-29 at 7 46 13 PM" src="https://github.com/user-attachments/assets/71948443-2639-441b-bdbc-84d6a7e5feed" />
